### PR TITLE
Restrict Reporting/classification groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ won't show up until after the next update.
             'bot_name': os.getenv('TNS_BOT_NAME', ''),  # This is the BOT name associated with the above ID
             'api_key': os.getenv('TNS_API_KEY', ''),  # This is the API key for the associated BOT         
             'tns_base_url': 'https://sandbox.wis-tns.org/api',  # This is the sandbox URL. Use https://www.wis-tns.org/api for live submission.
-            'group_names': os.getenv('TNS_GROUP_NAMES', '[]'),  # Optional List. Include if you wish to use any affiliated Group Names when reporting.
+            'group_names': ['bot_group', 'PI_group'],  # Optional List. Include if you wish to use any affiliated Group Names when reporting.
         },
     }
     ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ won't show up until after the next update.
             'bot_name': os.getenv('TNS_BOT_NAME', ''),  # This is the BOT name associated with the above ID
             'api_key': os.getenv('TNS_API_KEY', ''),  # This is the API key for the associated BOT         
             'tns_base_url': 'https://sandbox.wis-tns.org/api',  # This is the sandbox URL. Use https://www.wis-tns.org/api for live submission.
-            'group_name': os.getenv('TNS_GROUP_NAME', ''),  # Optional. Include if you wish to use an affiliated Group Name.
+            'group_names': os.getenv('TNS_GROUP_NAMES', '[]'),  # Optional List. Include if you wish to use any affiliated Group Names when reporting.
         },
     }
     ```

--- a/tom_tns/forms.py
+++ b/tom_tns/forms.py
@@ -40,7 +40,6 @@ class TNSReportForm(forms.Form):
         Also define the form layout using crispy_forms.
         """
         super().__init__(*args, **kwargs)
-        self.fields['reporting_group'].choices = get_tns_values('groups')
         self.fields['discovery_data_source'].choices = get_tns_values('groups')
         self.fields['at_type'].choices = get_tns_values('at_types')
         self.fields['at_type'].initial = (1, "PSN")
@@ -53,13 +52,19 @@ class TNSReportForm(forms.Form):
         self.fields['flux_units'].choices = get_tns_values('units')
         self.fields['flux_units'].initial = (1, "ABMag")
 
-        # set initial group if tom_name is in the list of tns group names
-        tns_group_name = get_tns_credentials().get('group_name', None)
-        if not tns_group_name:
-            tns_group_name = settings.TOM_NAME
-        default_group = get_reverse_tns_values('groups', tns_group_name)
+        # set choices of reporting groups to list set in settings.py
+        bot_tns_group_names = get_tns_credentials().get('group_names', [])
+        if not bot_tns_group_names:
+            bot_tns_group_names = [settings.TOM_NAME]
+        tns_group_list = []
+        for bot_group_name in bot_tns_group_names:
+            if get_reverse_tns_values('groups', bot_group_name):
+                tns_group_list.append(get_reverse_tns_values('groups', bot_group_name))
+        tns_group_list.append(get_reverse_tns_values('groups', 'None'))
+        self.fields['reporting_group'].choices = tns_group_list
+        # set initial group for discovery source if tom_name is in the list of tns group names
+        default_group = tns_group_list[0]
         if default_group:
-            self.fields['reporting_group'].initial = default_group
             self.fields['discovery_data_source'].initial = default_group
 
         self.helper = FormHelper()
@@ -171,20 +176,22 @@ class TNSClassifyForm(forms.Form):
         Also define the form layout using crispy-forms.
         """
         super().__init__(*args, **kwargs)
-        self.fields['reporting_group'].choices = get_tns_values('groups')
         self.fields['instrument'].choices = get_tns_values('instruments')
         self.fields['instrument'].initial = (0, "Other")
         self.fields['classification'].choices = get_tns_values('object_types')
         self.fields['classification'].initial = (1, "SN")
         self.fields['spectrum_type'].choices = get_tns_values('spectra_types')
 
-        # set initial group if tom_name is in the list of tns group names
-        tns_group_name = get_tns_credentials().get('group_name', None)
-        if not tns_group_name:
-            tns_group_name = settings.TOM_NAME
-        default_group = get_reverse_tns_values('groups', tns_group_name)
-        if default_group:
-            self.fields['reporting_group'].initial = default_group
+        # set choices of reporting groups to list set in settings.py
+        bot_tns_group_names = get_tns_credentials().get('group_names', [])
+        if not bot_tns_group_names:
+            bot_tns_group_names = [settings.TOM_NAME]
+        tns_group_list = []
+        for bot_group_name in bot_tns_group_names:
+            if get_reverse_tns_values('groups', bot_group_name):
+                tns_group_list.append(get_reverse_tns_values('groups', bot_group_name))
+        tns_group_list.append(get_reverse_tns_values('groups', 'None'))
+        self.fields['reporting_group'].choices = tns_group_list
 
         self.helper = FormHelper()
         self.helper.layout = Layout(

--- a/tom_tns/forms.py
+++ b/tom_tns/forms.py
@@ -40,7 +40,7 @@ class TNSReportForm(forms.Form):
         Also define the form layout using crispy_forms.
         """
         super().__init__(*args, **kwargs)
-        self.fields['discovery_data_source'].choices = get_tns_values('groups')
+        self.fields['discovery_data_source'].choices = sorted(get_tns_values('groups'), key=lambda x: x[1])
         self.fields['at_type'].choices = get_tns_values('at_types')
         self.fields['at_type'].initial = (1, "PSN")
         self.fields['filter'].choices = get_tns_values('filters')


### PR DESCRIPTION
Only the approved groups affiliated with a PI or the TNS bot used by the TOM should be available to use as a reporting group.

This checks that any listeg groups are valid in the TNS and limits the choices to only those provided in `settings.py`.