### PR TITLE
Feature/hermes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ TOMtoolkit module for reporting transients to the TNS
     ]
     ```
 
-3. Add your TNS credentials to your `settings.py` if they don't already exist for the TNS Broker.
+3. Add TNS or Hermes account credentials to your `settings.py` to enable different methods of sharing.
    
    If you don't have access to a TNS Bot for your TOM, you can make one from the [TNS website](https://www.wis-tns.org/bots).
+
+   NOTE: If you are testing on the sandbox, the sandbox is only synced every Sunday, so new bots created using the above link won't show up until after the next update.
+
+   ### Submit to TNS directly (no hermes)
+   Add your TNS credentials to your `settings.py` if they don't already exist for the TNS Broker.
    
-   NOTE: If you are testing on the sandbox, the sandbox is only synced every Sunday, so new bots created using the above link 
-won't show up until after the next update.
 
    ```python
     BROKERS = {
@@ -33,11 +36,44 @@ won't show up until after the next update.
             'api_key': os.getenv('TNS_API_KEY', ''),  # This is the API key for the associated BOT         
             'tns_base_url': 'https://sandbox.wis-tns.org/api',  # This is the sandbox URL. Use https://www.wis-tns.org/api for live submission.
             'group_names': ['bot_group', 'PI_group'],  # Optional List. Include if you wish to use any affiliated Group Names when reporting.
+            'filter_mapping': {
+                'o': 'Other',
+                'c': 'Clear',
+                ...
+            },  # Optional mapping from your reduced datum filter values to TNS filter options.
+            'default_authors': 'Foo Bar <foo@bar.com>'  # Optional default authors string to populate the author fields for tns submission. If not specified, defaults to saying "<logged in user> using <tom name>".
         },
     }
     ```
 
-5. Include the tom_tns URLconf in your project `urls.py`:
+    ### Submit to TNS through Hermes
+    If you want to submit to the TNS through [HERMES](https://hermes.lco.global), then you must first configure your [hermes account profile](https://hermes.lco.global/profile) to have your TNS credentials associated with your account. Then you must add your hermes credentials you `settings.py` in the `DATA_SHARING` section. This method of TNS submission will take precedence if `ENABLE_TNS` is set to True in your hermes `DATA_SHARING` details.
+
+    NOTE: If you don't set TNS credentials in your hermes account profile, TNS submission will still work but use the default Hermes_Bot account for TNS submission.
+
+
+   ```python
+    DATA_SHARING = {
+        ...
+        'hermes': {
+            'DISPLAY_NAME': 'hermes',
+            'BASE_URL': 'https://hermes-dev.lco.global/',
+            'HERMES_API_KEY': 'YourHermesAPITokenHere',
+            'DEFAULT_AUTHORS': 'String of default author list for your submissions heres',  # Optional default authors string to populate the author fields for tns submission. If not specified, defaults to saying "<logged in user> using <tom name>".
+            'USER_TOPICS': ['hermes.discovery', 'hermes.classification', ...]  # This is a list of hermes topics you will be allowed to share on. hermes.discovery and hermes.classification are automatically used for TNS submissions of those types.
+            'TNS_GROUP_NAMES': ['bot_group', 'PI_group'],  # Optional List. Include if you wish to use any affiliated Group Names when reporting to TNS.
+            'FILTER_MAPPING': {
+                'o': 'Other',
+                'c': 'Clear',
+                ...
+            },  # Optional mapping from your reduced datum filter values to TNS filter options.
+            'ENABLE_TNS': False  # Set to True to enable TNS submissions through Hermes
+        },
+    }
+    ```
+
+
+4. Include the tom_tns URLconf in your project `urls.py`:
    ```python
    urlpatterns = [
         ...
@@ -45,6 +81,17 @@ won't show up until after the next update.
    ]
    ```
 
-Once configured, a `TNS` button should appear below the Target Name.
+Once configured, a `TNS` button should appear below the Target Name on the default Target Detail page.
+
+If you have customized the Target Details page of your TOM, or if you would like to add entrypoints to the tom_tns form from other TOM pages, including those referencing a specific data product or reduced datum's values, then you can do that by including the code below somewhere in your templates:
+
+```html
+ <a href="{% url tns:report-tns pk=target.id datum_pk=datum.pk %}" title=TNS class="btn  btn-info">Submit to TNS</a>
+```
+
+The datum_pk is optional. If it is not specified, the latest photometry reduced datum will be used to pre-fill the discovery report form, and the latest spectroscopy reduced datum will be used to pre-fill the classification report form. If you specifiy a datum pk, then that datum and associated data product will be used to pre-fill the proper forms.
+
+For example, if you want to add a link next to each data product to submit it to TNS, then you could just use the dataproducts first datum id for the `datum_pk`.
+
 
 NOTE: Users who are using `tomtoolkit<2.15.12` will have to add the TNS button manually.

--- a/tom_tns/forms.py
+++ b/tom_tns/forms.py
@@ -19,6 +19,7 @@ HERMES_FLUX_UNITS = [
     ("mJy", "mJy"), ("erg / s / cm² / Å", "erg / s / cm² / Å")
 ]
 
+
 class BaseReportForm(forms.Form):
     def is_set(self, field):
         if field in self.cleaned_data and self.cleaned_data[field]:
@@ -134,7 +135,8 @@ class TNSReportForm(BaseReportForm):
             Row(Column('photometry_remarks')),
             Row(HTML('<h4>Last Nondetection</h4>')),
             Alert(
-                content="""Fill out either the Archive information, or the Detection information for the last nondetection
+                content="""Fill out either the Archive information,
+                           or the Detection information for the last nondetection
                         """,
                 css_class='alert-warning'
             ),
@@ -146,18 +148,18 @@ class TNSReportForm(BaseReportForm):
                                   ),
                                ),
                 AccordionGroup('Detection information',
-                                Row(
+                               Row(
                                     Column('nondetection_observation_date'),
                                     Column('nondetection_instrument'),
                                     Column('nondetection_exposure_time'),
                                     Column('nondetection_observer'),
-                                   ),
-                                Row(
+                                  ),
+                               Row(
                                     Column('nondetection_flux'),
                                     Column('nondetection_flux_units'),
                                     Column('nondetection_filter'),
-                                   ),
-                                Row(Column('nondetection_remarks', css_class='col-md-12'))
+                                  ),
+                               Row(Column('nondetection_remarks', css_class='col-md-12'))
                                )
             ),
             Row(Column(Submit('submit', 'Submit Report'))),
@@ -170,7 +172,10 @@ class TNSReportForm(BaseReportForm):
             if any([not self.is_set(field) for field in [
                 'nondetection_flux', 'nondetection_instrument', 'nondetection_filter', 'nondetection_observation_date'
             ]]):
-                raise ValidationError("Must set either last nondetection archival information, or last nondetection flux, obsdate, filter and instrument")
+                raise ValidationError(
+                    "Must set either last nondetection archival information,"
+                    "or last nondetection flux, obsdate, filter and instrument"
+                )
 
     def generate_hermes_report(self):
         """
@@ -192,8 +197,10 @@ class TNSReportForm(BaseReportForm):
                     'new_discovery': True,
                     'discovery_info': {
                         'date': self.cleaned_data['discovery_date'].isoformat(),
-                        'discovery_source': dict(self.fields['discovery_data_source'].choices)[self.cleaned_data['discovery_data_source']],
-                        'reporting_group': dict(self.fields['reporting_group'].choices)[self.cleaned_data['reporting_group']],
+                        'discovery_source': dict(
+                            self.fields['discovery_data_source'].choices)[self.cleaned_data['discovery_data_source']],
+                        'reporting_group': dict(
+                            self.fields['reporting_group'].choices)[self.cleaned_data['reporting_group']],
                         'transient_type': dict(self.fields['at_type'].choices)[int(self.cleaned_data['at_type'])],
                     }
                 }],
@@ -220,11 +227,13 @@ class TNSReportForm(BaseReportForm):
             hermes_report['data']['photometry'][0]['limiting_brightness'] = self.cleaned_data['limiting_flux']
 
         if self.is_set('archiveid') and self.is_set('archival_remarks'):
-            hermes_report['data']['targets'][0]['discovery_info']['nondetection_source'] = dict(self.fields['archiveid'].choices)[self.cleaned_data['archiveid']]
-            hermes_report['data']['targets'][0]['discovery_info']['nondetection_comments'] = self.cleaned_data['archival_remarks']
+            discovery_info = hermes_report['data']['targets'][0]['discovery_info']
+            discovery_info['nondetection_source'] = dict(
+                self.fields['archiveid'].choices)[self.cleaned_data['archiveid']]
+            discovery_info['nondetection_comments'] = self.cleaned_data['archival_remarks']
         elif all([self.is_set(field) for field in [
-                'nondetection_flux', 'nondetection_instrument', 'nondetection_filter', 'nondetection_observation_date'
-            ]]):
+            'nondetection_flux', 'nondetection_instrument', 'nondetection_filter', 'nondetection_observation_date'
+        ]]):
             nondetection = {
                 'limiting_brightness': self.cleaned_data['nondetection_flux'],
                 'limiting_brightness_unit': self.cleaned_data['nondetection_flux_units'],
@@ -409,7 +418,8 @@ class TNSClassifyForm(BaseReportForm):
                     'dec': self.cleaned_data['dec'],
                     'new_discovery': False,
                     'discovery_info': {
-                        'reporting_group': dict(self.fields['reporting_group'].choices)[self.cleaned_data['reporting_group']]
+                        'reporting_group': dict(
+                            self.fields['reporting_group'].choices)[self.cleaned_data['reporting_group']]
                     }
                 }],
                 'spectroscopy': [{

--- a/tom_tns/forms.py
+++ b/tom_tns/forms.py
@@ -2,16 +2,33 @@ import requests
 
 from django import forms
 from django.conf import settings
+from django.core.exceptions import ValidationError
 
-from tom_tns.tns_api import get_tns_values, get_tns_credentials, get_reverse_tns_values, pre_upload_files_to_tns
+from tom_tns.tns_api import (get_tns_values, get_tns_credentials, get_reverse_tns_values,
+                             pre_upload_files_to_tns, submit_through_hermes)
+from tom_dataproducts.models import DataProduct
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Row, Column, Submit, HTML
-from crispy_forms.bootstrap import AppendedText
+from crispy_forms.bootstrap import AppendedText, Alert, Accordion, AccordionGroup
 from datetime import datetime
 
 
-class TNSReportForm(forms.Form):
+HERMES_FLUX_UNITS = [
+    ("AB mag", "AB mag"), ("Vega mag", "Vega mag"),
+    ("mJy", "mJy"), ("erg / s / cm² / Å", "erg / s / cm² / Å")
+]
+
+class BaseReportForm(forms.Form):
+    def is_set(self, field):
+        if field in self.cleaned_data and self.cleaned_data[field]:
+            return True
+        return False
+
+
+class TNSReportForm(BaseReportForm):
+    submitter = forms.CharField(required=True, widget=forms.HiddenInput())
+    object_name = forms.CharField(required=True, widget=forms.HiddenInput())
     ra = forms.FloatField(label='R.A.')
     dec = forms.FloatField(label='Dec.')
     reporting_group = forms.ChoiceField(choices=[])
@@ -19,8 +36,15 @@ class TNSReportForm(forms.Form):
     reporter = forms.CharField(widget=forms.Textarea(attrs={'rows': 1}), label='Reporter Name(s) / Author List')
     discovery_date = forms.DateTimeField(initial=datetime.utcnow())
     at_type = forms.ChoiceField(choices=[], label='AT type')
-    archive = forms.ChoiceField(choices=[])
-    archival_remarks = forms.CharField()
+    archive = forms.ChoiceField(required=False, choices=[])
+    archival_remarks = forms.CharField(required=False)
+    nondetection_observation_date = forms.DateTimeField(required=False, label='Observation date')
+    nondetection_flux = forms.FloatField(required=False, label='Flux')
+    nondetection_flux_units = forms.ChoiceField(choices=[], required=False, label='Flux units')
+    nondetection_filter = forms.ChoiceField(choices=[], required=False, label='Filter')
+    nondetection_instrument = forms.ChoiceField(choices=[], required=False, label='Instrument')
+    nondetection_observer = forms.CharField(required=False, label='Observer')
+    nondetection_exposure_time = forms.FloatField(required=False, label='Exposure time')
     observation_date = forms.DateTimeField()
     flux = forms.FloatField()
     flux_error = forms.FloatField()
@@ -44,13 +68,25 @@ class TNSReportForm(forms.Form):
         self.fields['at_type'].choices = get_tns_values('at_types')
         self.fields['at_type'].initial = (1, "PSN")
         self.fields['filter'].choices = get_tns_values('filters')
-        self.fields['filter'].initial = (22, "r-Sloan")
+        self.fields['filter'].initial = ("22", "r-Sloan")
+        self.fields['nondetection_filter'].choices = get_tns_values('filters')
+        self.fields['nondetection_filter'].initial = ("22", "r-Sloan")
         self.fields['archive'].choices = get_tns_values('archives')
-        self.fields['archive'].initial = (0, "Other")
+        self.fields['archive'].initial = ("0", "Other")
         self.fields['instrument'].choices = get_tns_values('instruments')
-        self.fields['instrument'].initial = (0, "Other")
-        self.fields['flux_units'].choices = get_tns_values('units')
-        self.fields['flux_units'].initial = (1, "ABMag")
+        self.fields['instrument'].initial = ("0", "Other")
+        self.fields['nondetection_instrument'].choices = get_tns_values('instruments')
+        self.fields['nondetection_instrument'].initial = ("0", "Other")
+        if submit_through_hermes():
+            self.fields['flux_units'].choices = HERMES_FLUX_UNITS
+            self.fields['flux_units'].initial = ("AB mag", "AB mag")
+            self.fields['nondetection_flux_units'].choices = HERMES_FLUX_UNITS
+            self.fields['nondetection_flux_units'].initial = ("AB mag", "AB mag")
+        else:
+            self.fields['flux_units'].choices = get_tns_values('units')
+            self.fields['flux_units'].initial = (1, "ABMag")
+            self.fields['nondetection_flux_units'].choices = get_tns_values('units')
+            self.fields['nondetection_flux_units'].initial = (1, "ABMag")
 
         # set choices of reporting groups to list set in settings.py
         bot_tns_group_names = get_tns_credentials().get('group_names', [])
@@ -69,6 +105,7 @@ class TNSReportForm(forms.Form):
 
         self.helper = FormHelper()
         self.helper.layout = Layout(
+            'submitter', 'object_name',
             Row(
                 Column('reporter', css_class='col-md-6'),
                 Column('reporting_group'),
@@ -96,13 +133,114 @@ class TNSReportForm(forms.Form):
             ),
             Row(Column('photometry_remarks')),
             Row(HTML('<h4>Last Nondetection</h4>')),
-            Row(
-                Column('archive'),
-                Column('archival_remarks'),
-                Column('nondetection_remarks', css_class='col-md-6'),
+            Alert(
+                content="""Fill out either the Archive information, or the Detection information for the last nondetection
+                        """,
+                css_class='alert-warning'
+            ),
+            Accordion(
+                AccordionGroup('Archive information',
+                               Row(
+                                    Column('archive'),
+                                    Column('archival_remarks'),
+                                  ),
+                               ),
+                AccordionGroup('Detection information',
+                                Row(
+                                    Column('nondetection_observation_date'),
+                                    Column('nondetection_instrument'),
+                                    Column('nondetection_exposure_time'),
+                                    Column('nondetection_observer'),
+                                   ),
+                                Row(
+                                    Column('nondetection_flux'),
+                                    Column('nondetection_flux_units'),
+                                    Column('nondetection_filter'),
+                                   ),
+                                Row(Column('nondetection_remarks', css_class='col-md-12'))
+                               )
             ),
             Row(Column(Submit('submit', 'Submit Report'))),
         )
+
+    def clean(self):
+        super().clean()
+        # Either the archival info or nondetection flux info must be set for a valid TNS submission
+        if not self.is_set('archiveid') or not self.is_set('archival_remarks'):
+            if any([not self.is_set(field) for field in [
+                'nondetection_flux', 'nondetection_instrument', 'nondetection_filter', 'nondetection_observation_date'
+            ]]):
+                raise ValidationError("Must set either last nondetection archival information, or last nondetection flux, obsdate, filter and instrument")
+
+    def generate_hermes_report(self):
+        """
+        Generate Hermes TNS discovery report according to the hermes schema
+
+        Returns the report as a Dict to be sent as JSON
+        """
+        hermes_report = {
+            'topic': 'hermes.discovery',
+            'title': f'{self.cleaned_data["object_name"]} TNS discovery report',
+            'submit_to_tns': True,
+            'submitter': self.cleaned_data['submitter'],
+            'authors': self.cleaned_data['reporter'],  # TODO: Set the initial authors on the field from the settings
+            'data': {
+                'targets': [{
+                    'name': self.cleaned_data['object_name'],
+                    'ra': self.cleaned_data['ra'],
+                    'dec': self.cleaned_data['dec'],
+                    'new_discovery': True,
+                    'discovery_info': {
+                        'date': self.cleaned_data['discovery_date'].isoformat(),
+                        'discovery_source': dict(self.fields['discovery_data_source'].choices)[self.cleaned_data['discovery_data_source']],
+                        'reporting_group': dict(self.fields['reporting_group'].choices)[self.cleaned_data['reporting_group']],
+                        'transient_type': dict(self.fields['at_type'].choices)[int(self.cleaned_data['at_type'])],
+                    }
+                }],
+                'photometry': [{
+                    'target_name': self.cleaned_data['object_name'],
+                    'date_obs': self.cleaned_data['observation_date'].isoformat(),
+                    'instrument': dict(self.fields['instrument'].choices)[self.cleaned_data['instrument']],
+                    'bandpass': dict(self.fields['filter'].choices)[self.cleaned_data['filter']],
+                    "brightness": self.cleaned_data['flux'],
+                    "brightness_error": self.cleaned_data['flux_error'],
+                    "brightness_unit": self.cleaned_data['flux_units'],
+                }]
+            },
+        }
+        if self.is_set('discovery_remarks'):
+            hermes_report['data']['targets'][0]['comments'] = self.cleaned_data['discovery_remarks']
+        if self.is_set('photometry_remarks'):
+            hermes_report['data']['photometry'][0]['comments'] = self.cleaned_data['photometry_remarks']
+        if self.is_set('exposure_time'):
+            hermes_report['data']['photometry'][0]['exposure_time'] = self.cleaned_data['exposure_time']
+        if self.is_set('observer'):
+            hermes_report['data']['photometry'][0]['observer'] = self.cleaned_data['observer']
+        if self.is_set('limiting_flux'):
+            hermes_report['data']['photometry'][0]['limiting_brightness'] = self.cleaned_data['limiting_flux']
+
+        if self.is_set('archiveid') and self.is_set('archival_remarks'):
+            hermes_report['data']['targets'][0]['discovery_info']['nondetection_source'] = dict(self.fields['archiveid'].choices)[self.cleaned_data['archiveid']]
+            hermes_report['data']['targets'][0]['discovery_info']['nondetection_comments'] = self.cleaned_data['archival_remarks']
+        elif all([self.is_set(field) for field in [
+                'nondetection_flux', 'nondetection_instrument', 'nondetection_filter', 'nondetection_observation_date'
+            ]]):
+            nondetection = {
+                'limiting_brightness': self.cleaned_data['nondetection_flux'],
+                'limiting_brightness_unit': self.cleaned_data['nondetection_flux_units'],
+                'date_obs': self.cleaned_data['nondetection_observation_date'],
+                'bandpass': self.cleaned_data['nondetection_filter'],
+                'instrument': self.cleaned_data['nondetection_instrument'],
+            }
+            if self.is_set('nondetection_exposure_time'):
+                nondetection['exposure_time'] = self.cleaned_data['nondetection_exposure_time']
+            if self.is_set('nondetection_observer'):
+                nondetection['observer'] = self.cleaned_data['nondetection_observer']
+            if self.is_set('nondetection_remarks'):
+                nondetection['comments'] = self.cleaned_data['nondetection_remarks']
+            hermes_report['data']['photometry'].append(nondetection)
+
+        return hermes_report, []
 
     def generate_tns_report(self):
         """
@@ -153,11 +291,14 @@ class TNSReportForm(forms.Form):
         return report_data
 
 
-class TNSClassifyForm(forms.Form):
-    object_name = forms.CharField()
+class TNSClassifyForm(BaseReportForm):
+    submitter = forms.CharField(required=False, widget=forms.HiddenInput())
+    object_name = forms.CharField(required=False)
+    ra = forms.FloatField(required=False, widget=forms.HiddenInput())
+    dec = forms.FloatField(required=False, widget=forms.HiddenInput())
     classifier = forms.CharField(widget=forms.Textarea(attrs={'rows': 1}), label='Classifier Name(s) / Author List')
     classification = forms.ChoiceField(choices=[])
-    redshift = forms.FloatField(required=False)
+    redshift = forms.FloatField(required=False, widget=forms.TextInput())
     reporting_group = forms.ChoiceField(choices=[])
     classification_remarks = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 2}))
     observation_date = forms.DateTimeField()
@@ -166,8 +307,12 @@ class TNSClassifyForm(forms.Form):
     observer = forms.CharField()
     reducer = forms.CharField(required=False)
     spectrum_type = forms.ChoiceField(choices=[])
-    ascii_file = forms.FileField(label='ASCII file', required=True, widget=forms.ClearableFileInput())
-    fits_file = forms.FileField(label='FITS file', required=False, widget=forms.ClearableFileInput())
+    ascii_file = forms.ChoiceField(label='ASCII file', choices=[], required=True)
+    fits_file = forms.ChoiceField(label='FITS file', choices=[], required=False)
+    ascii_file_description = forms.CharField(label='ASCII file description', required=False)
+    fits_file_description = forms.CharField(label='FITS file description', required=False)
+    ascii_file_override = forms.FileField(label='ASCII file override', required=False, widget=forms.FileInput())
+    fits_file_override = forms.FileField(label='FITS file override', required=False, widget=forms.FileInput())
     spectrum_remarks = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 2}))
 
     def __init__(self, *args, **kwargs):
@@ -181,6 +326,8 @@ class TNSClassifyForm(forms.Form):
         self.fields['classification'].choices = get_tns_values('object_types')
         self.fields['classification'].initial = (1, "SN")
         self.fields['spectrum_type'].choices = get_tns_values('spectra_types')
+        self.fields['ascii_file'].choices = kwargs['initial']['ascii_file_choices']
+        self.fields['fits_file'].choices = kwargs['initial']['fits_file_choices']
 
         # set choices of reporting groups to list set in settings.py
         bot_tns_group_names = get_tns_credentials().get('group_names', [])
@@ -195,6 +342,7 @@ class TNSClassifyForm(forms.Form):
 
         self.helper = FormHelper()
         self.helper.layout = Layout(
+            'submitter', 'ra', 'dec',
             Row(
                 Column('classifier', css_class='col-md-8'),
                 Column('reporting_group'),
@@ -220,9 +368,85 @@ class TNSClassifyForm(forms.Form):
                 Column('ascii_file'),
                 Column('fits_file'),
             ),
+            Row(
+                Column('ascii_file_override'),
+                Column('fits_file_override'),
+            ),
+            Row(
+                Column('ascii_file_description'),
+                Column('fits_file_description'),
+            ),
             Row(Column('spectrum_remarks')),
             Row(Column(Submit('submit', 'Submit Classification'))),
         )
+
+    def generate_hermes_report(self):
+        """
+        Generate Hermes TNS classification report according to the hermes schema
+
+        Returns the report as a Dict to be sent as JSON
+        """
+        if self.is_set('ascii_file_override'):
+            ascii_file = self.cleaned_data['ascii_file_override']
+        else:
+            ascii_file = DataProduct.objects.get(pk=self.cleaned_data['ascii_file']).data
+        if self.is_set('fits_file_override'):
+            fits_file = self.cleaned_data['fits_file_override']
+        elif self.is_set('fits_file'):
+            fits_file = DataProduct.objects.get(pk=self.cleaned_data['fits_file']).data
+        else:
+            fits_file = None
+        hermes_report = {
+            'topic': 'hermes.classification',
+            'title': f'{self.cleaned_data["object_name"]} TNS classification report',
+            'submit_to_tns': True,
+            'submitter': self.cleaned_data['submitter'],
+            'authors': self.cleaned_data['classifier'],  # TODO: Set the initial authors on the field from the settings
+            'data': {
+                'targets': [{
+                    'name': self.cleaned_data['object_name'],
+                    'ra': self.cleaned_data['ra'],
+                    'dec': self.cleaned_data['dec'],
+                    'new_discovery': False,
+                    'discovery_info': {
+                        'reporting_group': dict(self.fields['reporting_group'].choices)[self.cleaned_data['reporting_group']]
+                    }
+                }],
+                'spectroscopy': [{
+                    'target_name': self.cleaned_data['object_name'],
+                    'date_obs': self.cleaned_data['observation_date'].isoformat(),
+                    'instrument': dict(self.fields['instrument'].choices)[self.cleaned_data['instrument']],
+                    'spec_type': dict(self.fields['spectrum_type'].choices)[self.cleaned_data['spectrum_type']],
+                    'classification': dict(self.fields['classification'].choices)[self.cleaned_data['classification']],
+                    'observer': self.cleaned_data['observer'],
+                    'file_info': [
+                        {
+                            'name': ascii_file.name,
+                            'description': self.cleaned_data.get('ascii_file_description', '')
+                        }
+                    ]
+                }]
+            },
+        }
+        files = [ascii_file]
+        if self.is_set('redshift'):
+            hermes_report['data']['targets'][0]['redshift'] = self.cleaned_data['redshift']
+        if self.is_set('classification_remarks'):
+            hermes_report['data']['targets'][0]['comments'] = self.cleaned_data['classification_remarks']
+        if self.is_set('reducer'):
+            hermes_report['data']['spectroscopy'][0]['reducer'] = self.cleaned_data['reducer']
+        if self.is_set('exposure_time'):
+            hermes_report['data']['spectroscopy'][0]['exposure_time'] = self.cleaned_data['exposure_time']
+        if fits_file:
+            hermes_report['data']['spectroscopy'][0]['file_info'].append({
+                'name': fits_file.name,
+                'description': self.cleaned_data.get('fits_file_description', '')
+            })
+            files.append(fits_file)
+        if self.is_set('spectrum_remarks'):
+            hermes_report['data']['spectroscopy'][0]['comments'] = self.cleaned_data['spectrum_remarks']
+
+        return hermes_report, files
 
     def generate_tns_report(self):
         """
@@ -231,8 +455,18 @@ class TNSClassifyForm(forms.Form):
 
         Returns the report as a JSON-formatted string
         """
-        file_list = {'ascii_file': self.cleaned_data['ascii_file'],
-                     'fits_file': self.cleaned_data['fits_file'],
+        if self.is_set('ascii_file_override'):
+            ascii_file = self.cleaned_data['ascii_file_override']
+        else:
+            ascii_file = DataProduct.objects.get(pk=self.cleaned_data['ascii_file']).data
+        if self.is_set('fits_file_override'):
+            fits_file = self.cleaned_data['fits_file_override']
+        elif self.is_set('fits_file'):
+            fits_file = DataProduct.objects.get(pk=self.cleaned_data['fits_file']).data
+        else:
+            fits_file = None
+        file_list = {'ascii_file': ascii_file,
+                     'fits_file': fits_file,
                      'other_files': []}
         try:
             tns_filenames = pre_upload_files_to_tns(file_list)

--- a/tom_tns/hermes_api.py
+++ b/tom_tns/hermes_api.py
@@ -1,0 +1,56 @@
+from django.conf import settings
+from django.contrib import messages
+from urllib.parse import urljoin
+
+import requests
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def get_object_from_response(response_json):
+    # If the submission is successful, then pull out the tns_object name from the references and return it
+    references = response_json.get('data', {}).get('references', [])
+    for reference in references:
+        if reference.get('source') == 'tns_object':
+            return reference.get('citation')
+    return None
+
+
+def submit_to_hermes(hermes_message, files, request):
+    hermes_submit_url = urljoin(settings.DATA_SHARING.get('hermes', {}).get('BASE_URL', ''), 'api/v0/submit_message/')
+    headers = {'Authorization': f"Token {settings.DATA_SHARING.get('hermes', {}).get('HERMES_API_KEY', '')}"}
+    response_json = {}
+    try:
+        if not files:
+            # Can submit simple json payload to hermes, and this assumed to be a new discovery
+            response = requests.post(url=hermes_submit_url, json=hermes_message, headers=headers)
+            response_json = response.json()
+            response.raise_for_status()
+            logger.info(f"Sent TNS discovery message through Hermes with uuid {response_json.get('uuid')}")
+            return get_object_from_response(response_json)
+        else:
+            # There are files, so this must be a classification submission
+            data = {'data': json.dumps(hermes_message)}
+            files_to_submit = []
+            for file in files:
+                content_type = 'text/plain'
+                if file.name.endswith('fits') or file.name.endswith('fits.fz'):
+                    content_type = 'application/fits'
+                files_to_submit.append(('files', (os.path.basename(file.name), file.open('rb'), content_type)))
+            response = requests.post(url=hermes_submit_url, data=data, files=files_to_submit, headers=headers)
+            response_json = response.json()
+            response.raise_for_status()
+            logger.info(f"Sent TNS classification message through Hermes with uuid {response_json.get('uuid')}")
+            return get_object_from_response(response_json)
+    except Exception as e:
+        error_msg = 'Failed to Submit message to Hermes/TNS'
+        if response_json:
+            error_msg += f': {response_json}'
+        else:
+            error_msg += f': {repr(e)}'
+        logger.error(error_msg)
+        messages.error(request, error_msg)
+    return None    

--- a/tom_tns/hermes_api.py
+++ b/tom_tns/hermes_api.py
@@ -53,4 +53,4 @@ def submit_to_hermes(hermes_message, files, request):
             error_msg += f': {repr(e)}'
         logger.error(error_msg)
         messages.error(request, error_msg)
-    return None    
+    return None

--- a/tom_tns/templatetags/tns_extras.py
+++ b/tom_tns/templatetags/tns_extras.py
@@ -1,7 +1,7 @@
 from django import template
 from django.conf import settings
 
-from tom_tns.tns_api import get_tns_values
+from tom_tns.tns_api import get_tns_values, map_filter_to_tns, default_authors
 from tom_tns.forms import TNSReportForm, TNSClassifyForm
 
 register = template.Library()
@@ -21,21 +21,34 @@ def report_to_tns(context):
     """
     target = context['target']
     initial = {
+        'object_name': target.name,
         'ra': target.ra,
         'dec': target.dec,
+        'submitter': context['request'].user.email,
         'reporter': f"{getattr(context['request'].user, 'get_full_name()', 'Anonymous User')},"
                     f" using {settings.TOM_NAME}",
     }
-    # Get photometry if available
-    photometry = target.reduceddatum_set.filter(data_type='photometry')
-    if photometry.exists():
-        reduced_datum = photometry.latest()
+
+    reporter = default_authors()
+    if reporter:
+        initial['reporter'] = reporter
+
+    reduced_datum = None
+    if 'datum' in context:
+        reduced_datum = context['datum']
+    else:
+        # Get photometry if available
+        photometry = target.reduceddatum_set.filter(data_type='photometry')
+        if photometry.exists():
+            reduced_datum = photometry.latest()
+    if reduced_datum:
         initial['observation_date'] = reduced_datum.timestamp
         initial['flux'] = reduced_datum.value.get('magnitude')
         initial['flux_error'] = reduced_datum.value.get('error')
         filter_name = reduced_datum.value.get('filter')
-        if filter_name in TNS_FILTER_IDS:
-            initial['filter'] = (TNS_FILTER_IDS[filter_name], filter_name)
+        mapped_filter = map_filter_to_tns(filter_name)
+        if mapped_filter in TNS_FILTER_IDS:
+            initial['filter'] = (TNS_FILTER_IDS[mapped_filter], mapped_filter)
         instrument_name = reduced_datum.value.get('instrument')
         if instrument_name in TNS_INSTRUMENT_IDS:
             initial['instrument'] = (TNS_INSTRUMENT_IDS[instrument_name], instrument_name)
@@ -53,18 +66,44 @@ def classify_with_tns(context):
     target = context['target']
     initial = {
         'object_name': target.name.replace('AT', '').replace('SN', ''),
+        'ra': target.ra,
+        'dec': target.dec,
+        'submitter': context['request'].user.email,
         'classifier': f"{getattr(context['request'].user, 'get_full_name()', 'Anonymous User')},"
                       f" using {settings.TOM_NAME}",
     }
-    # Get spectroscopy if available
-    spectra = target.reduceddatum_set.filter(data_type='spectroscopy')
-    if spectra.exists():
-        reduced_datum = spectra.latest()
+
+    classifier = default_authors()
+    if classifier:
+        initial['classifier'] = classifier
+
+    # Get the list of chocies for ascii and fits files for those fields
+    ascii_files = []
+    fits_files = [(None, '')]
+    for data_product in target.dataproduct_set.all():
+        if data_product.get_file_extension().lower() in ['.ascii', '.txt']:
+            ascii_files.append((data_product.pk, data_product.get_file_name()))
+        elif data_product.get_file_extension().lower() in ['.fits', '.fits.fz']:
+            fits_files.append((data_product.pk, data_product.get_file_name()))
+    initial['ascii_file_choices'] = ascii_files
+    initial['fits_file_choices'] = fits_files
+
+    # Get the spectra details from the latest spectra reduced datum or one passed in
+    reduced_datum = None
+    if 'datum' in context:
+        reduced_datum = context['datum']
+    else:
+        spectra = target.reduceddatum_set.filter(data_type='spectroscopy')
+        if spectra.exists():
+            reduced_datum = spectra.latest()
+    if reduced_datum:
         initial['observation_date'] = reduced_datum.timestamp
-        initial['ascii_file'] = reduced_datum.data_product.data
+        if reduced_datum.data_product.get_file_extension().lower() in ['.ascii', '.txt']:
+            initial['ascii_file'] = (reduced_datum.data_product.pk, reduced_datum.data_product.get_file_name())
         instrument_name = reduced_datum.value.get('instrument')
         if instrument_name in TNS_INSTRUMENT_IDS:
             initial['instrument'] = (TNS_INSTRUMENT_IDS[instrument_name], instrument_name)
+
     tns_classify_form = TNSClassifyForm(initial=initial)
     return {'target': target,
             'form': tns_classify_form}

--- a/tom_tns/tns_api.py
+++ b/tom_tns/tns_api.py
@@ -16,6 +16,33 @@ class BadTnsRequest(Exception):
     pass
 
 
+def submit_through_hermes():
+    """ Check if hermes credentials exist and are setup so TNS messages should be sent through hermes
+        Returns True if it should go through hermes, False if it should go directly to TNS
+    """
+    if hasattr(settings, 'DATA_SHARING') and settings.DATA_SHARING.get('hermes', {}).get('ENABLE_TNS', False):
+        return True
+    return False
+
+
+def map_filter_to_tns(filter):
+    """ Checks if a filter mapping was set in the settings, and if so returns the mapped value for the filter passed in
+    """
+    if submit_through_hermes():
+        return settings.DATA_SHARING.get('hermes', {}).get('FILTER_MAPPING', {}).get(filter)
+    else:
+        return settings.BROKERS.get('TNS', {}).get('filter_mapping', {}).get(filter)
+
+
+def default_authors():
+    """ Returns default authors if set in the settings, otherwise empty string.
+    """
+    if submit_through_hermes():
+        return settings.DATA_SHARING.get('hermes', {}).get('DEFAULT_AUTHORS', '')
+    else:
+        return settings.BROKERS.get('TNS', {}).get('default_authors', '')
+
+
 def get_tns_credentials():
     """
     Get the TNS credentials from settings.py.

--- a/tom_tns/urls.py
+++ b/tom_tns/urls.py
@@ -7,6 +7,7 @@ app_name = 'tom_tns'
 
 urlpatterns = [
     path('<int:pk>/', TNSFormView.as_view(), name='report-tns'),
+    path('<int:pk>/<int:datum_pk>', TNSFormView.as_view(), name='report-tns'),
     path('<int:pk>/report', TNSSubmitView.as_view(form_class=TNSReportForm), name='submit-report'),
     path('<int:pk>/classify', TNSSubmitView.as_view(form_class=TNSClassifyForm), name='submit-classify'),
 ]

--- a/tom_tns/views.py
+++ b/tom_tns/views.py
@@ -8,8 +8,11 @@ from django.contrib import messages
 from guardian.mixins import PermissionListMixin
 
 from tom_tns import __version__
-from tom_tns.tns_api import send_tns_report, get_tns_report_reply, get_tns_credentials, BadTnsRequest
+from tom_tns.tns_api import (send_tns_report, get_tns_report_reply, get_tns_credentials,
+                             submit_through_hermes, BadTnsRequest)
+from tom_tns.hermes_api import submit_to_hermes
 from tom_targets.models import Target, TargetName
+from tom_dataproducts.models import ReducedDatum
 
 import json
 
@@ -23,14 +26,21 @@ class TNSFormView(PermissionListMixin, TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context['default_form'] = 'report'
         target = Target.objects.get(pk=self.kwargs['pk'])
+        if 'datum_pk' in self.kwargs:
+            try:
+                context['datum'] = ReducedDatum.objects.get(pk=self.kwargs['datum_pk'])
+                if context['datum'].data_type == 'spectroscopy':
+                    context['default_form'] = 'classify'
+            except ReducedDatum.DoesNotExist:
+                pass
         context['tns_configured'] = bool(get_tns_credentials())
         context['target'] = target
         context['version'] = __version__  # from tom_tns.__init__.py
         # We want to establish a default tab to display.
         # by default, we start on report, but change to classify if the target name starts with AT.
         # If the target has an SN name, we warn the user that the target has likely been classified already.
-        context['default_form'] = 'report'
         for name in target.names:
             if name.upper().startswith('AT'):
                 context['default_form'] = 'classify'
@@ -44,6 +54,20 @@ class TNSSubmitView(FormView):
     """
     This View is used to submit the TNS report forms.
     """
+    def get_initial(self):
+        # Must override get_initial to pass in the file choice options or it will fail validation
+        initial = super().get_initial()
+        target = Target.objects.get(pk=self.kwargs['pk'])
+        ascii_files = []
+        fits_files = [(None, '')]
+        for data_product in target.dataproduct_set.all():
+            if data_product.get_file_extension().lower() in ['.ascii', '.txt']:
+                ascii_files.append((data_product.pk, data_product.get_file_name()))
+            elif data_product.get_file_extension().lower() in ['.fits', '.fits.fz']:
+                fits_files.append((data_product.pk, data_product.get_file_name()))
+        initial['ascii_file_choices'] = ascii_files
+        initial['fits_file_choices'] = fits_files
+        return initial
 
     def get_success_url(self):
         return reverse_lazy('targets:detail', kwargs=self.kwargs)
@@ -58,21 +82,28 @@ class TNSSubmitView(FormView):
         If the Form is successfully constructed, we generate the TNS report and submit it to the TNS.
         """
         try:
-            # Build TNS Report
-            tns_report = form.generate_tns_report()
-            # Submit TNS Report
-            report_id = send_tns_report(json.dumps(tns_report))
-            # Get IAU name from Report Reply
-            iau_name = get_tns_report_reply(report_id, self.request)
-            if iau_name is not None:
+            iau_name = None
+            if submit_through_hermes():
+                hermes_report, files = form.generate_hermes_report()
+                iau_name = submit_to_hermes(hermes_report, files, self.request)
+            else:
+                # Build TNS Report
+                tns_report = form.generate_tns_report()
+                # Submit TNS Report
+                report_id = send_tns_report(json.dumps(tns_report))
+                # Get IAU name from Report Reply
+                iau_name = get_tns_report_reply(report_id, self.request)
+
+            if iau_name:
                 # update the target name in Tom DB
                 target = Target.objects.get(pk=self.kwargs['pk'])
-                old_name = target.name
-                target.name = iau_name
-                target.save()
-                # Save old name as alias
-                new_alias = TargetName(name=old_name, target=target)
-                new_alias.save()
+                if target.name != iau_name:
+                    old_name = target.name
+                    target.name = iau_name
+                    target.save()
+                    # Save old name as alias
+                    new_alias = TargetName(name=old_name, target=target)
+                    new_alias.save()
         except (requests.exceptions.HTTPError, BadTnsRequest) as e:
             messages.error(self.request, f'TNS returned an error: {e}')
         return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
This PR adds the ability to submit to TNS through Hermes (If Hermes info is defined in the DATA_SHARING section). I also enhanced the form a bit to have:

- Extra discovery parameters to specify a nondetection flux
- A set of choices for spectra files in a dropdown from the dataproducts associated with the target
- Descriptions for the files to send
- An endpoint for going to the TNS form with a specific ReducedDatum pk, which will use that datum to seed the initial info in the form

Please check out the README especially to see if that makes sense for the two modes of submission now. Also @jchate6 I added a bit at the bottom about how to include it into your TOM's templates - the idea was originally to add a button to the target details "manage data" or "photometry" and "spectroscopy" tabs to go to the tns form for a specific datum or data product, but I can't really see a way to "inject" that into this plugin? Please let me know if there is a way, but ff there isn't, then I think its fine to leave this as is since the main user SNEX uses fully custom target detail templates anyway, so they will need to add it themselves either way.